### PR TITLE
Improve test reliability by resolving nondeterministic order of Map

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/ajax/attributes/AjaxRequestAttributes.java
+++ b/wicket-core/src/main/java/org/apache/wicket/ajax/attributes/AjaxRequestAttributes.java
@@ -17,7 +17,7 @@
 package org.apache.wicket.ajax.attributes;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -276,7 +276,7 @@ public final class AjaxRequestAttributes
 	{
 		if (extraParameters == null)
 		{
-			extraParameters = new HashMap<>();
+			extraParameters = new LinkedHashMap<>();
 		}
 		return extraParameters;
 	}


### PR DESCRIPTION
# Problem 

For the test renderAjaxAttributes, we create the Json string from the AjaxRequestAttributes and assume the order of the fields in tests which is not true because it serialize from extraParameters which was a HashMap, which did not guarantee any order and will cause non-deterministic when we change the environments like JDK version. Also the LinkedHashMap is designed with specification to guarantee the order to resolve this kind of problem 


# Solution

Use LinkedHashMap

This problem had encounter and solved in the same way before : https://github.com/apache/wicket/blob/b243eca31ab4a0ab78159fd2ccf7337a38b94840/wicket-core/src/main/java/org/apache/wicket/ajax/json/README#L4C1-L4C1 

# Affected tests

- [INFO] org.apache.wicket.ajax.AbstractDefaultAjaxBehaviorTest#renderAjaxAttributes
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testCallbackFunctionWithConverted
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testCallbackFunctionWithExplicit
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testCallbackFunctionWithAll
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testCallbackFunctionWithContext
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testJQueryUIEvent
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testCallbackFunctionWithResolved
- [INFO] org.apache.wicket.ajax.AjaxCallbackFunctionTest#testDefaultCallbackFunction

# Reproduce

This error can be reproduced with the [NondexTool](https://github.com/TestingResearchIllinois/NonDex) with the following command (you can try that without modifying the pom, but feel free to use the plugin to protect your project and make it safer 😊 ), and this kind problem is widely documented in [International Dataset of Flaky Tests (IDoFT)](https://github.com/TestingResearchIllinois/idoft)

```
mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -pl ./wicket-core-tests -DnondexRuns=10 -Dtest=org.apache.
wicket.ajax.AbstractDefaultAjaxBehaviorTest#renderAjaxAttributes


mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -pl ./wicket-core-tests -DnondexRuns=10 -Dtest=org.apache.
wicket.ajax.AbstractDefaultAjaxBehaviorTest#[methodName]
```
